### PR TITLE
Updates for BGC build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-# ACCESS-OM2: ACCESS Ocean-Ice Model Release Configurations
+# ACCESS-OM2: ACCESS Ocean-Sea Ice Model with WOMBAT Biogeochemistry 
   
 ## About the model
   
-ACCESS-OM2 is a global coupled ocean - sea ice model developed by [COSIMA](http://www.cosima.org.au).
+ACCESS-OM2-BGC is a global coupled ocean - sea ice model with WOMBAT biogeochemistrydeveloped by [COSIMA](http://www.cosima.org.au).
   
-ACCESS-OM2 consists of the [MOM 5](https://github.com/ACCESS-NRI/MOM5) ocean model, [CICE 5](https://github.com/ACCESS-NRI/cice5) sea ice model, and a file-based atmosphere called [YATM](https://github.com/ACCESS-NRI/libaccessom2) coupled together using [OASIS3-MCT v2.0](https://github.com/ACCESS-NRI/oasis3-mct). ACCESS-OM2 builds on the ACCESS-OM ([Bi et al., 2013](http://www.bom.gov.au/jshess/docs/2013/bi2_hres.pdf)) and AusCOM ([Roberts et al., 2007](https://50years.acs.org.au/content/dam/acs/50-years/journals/jrpit/JRPIT39.2.137.pdf); [Bi and Marsland, 2010](https://www.cawcr.gov.au/technical-reports/CTR_027.pdf)) models originally developed at [CSIRO](http://www.csiro.au).
+ACCESS-OM2-BGC consists of the [MOM 5](https://github.com/ACCESS-NRI/MOM5) ocean model, [CICE 5](https://github.com/ACCESS-NRI/cice5) sea ice model, and a file-based atmosphere called [YATM](https://github.com/ACCESS-NRI/libaccessom2) coupled together using [OASIS3-MCT v2.0](https://github.com/ACCESS-NRI/oasis3-mct). ACCESS-OM2-BGC builds on the ACCESS-OM ([Bi et al., 2013](http://www.bom.gov.au/jshess/docs/2013/bi2_hres.pdf)) and AusCOM ([Roberts et al., 2007](https://50years.acs.org.au/content/dam/acs/50-years/journals/jrpit/JRPIT39.2.137.pdf); [Bi and Marsland, 2010](https://www.cawcr.gov.au/technical-reports/CTR_027.pdf)) models originally developed at [CSIRO](http://www.csiro.au).
   
 The model code, configurations and performance were described in [Kiss et al. (2020)](https://doi.org/10.5194/gmd-13-401-2020), with further details in the draft [ACCESS-OM2 technical report](https://github.com/COSIMA/ACCESS-OM2-1-025-010deg-report). The current code and configurations differ from this version in a number of ways (biogeochemistry, updated forcing, improvements and bug fixes), as described by [Solodoch et al. (2022)](https://doi.org/10.1029/2021GL097211), [Hayashida et al. (2023)](https://dx.doi.org/10.1029/2023JC019697), [Menviel et al. (2023)](https://doi.org/10.5194/egusphere-2023-390) and [Wang et al. (2023)](https://doi.org/10.5194/gmd-2023-123).
   
 ## Support
   
-[ACCESS-NRI](https://www.access-nri.org.au) has assumed responsibility for supporting ACCESS-OM2 for the Australian Research Community. As part of this support ACCESS-NRI has developed a new build and deployment system for ACCESS-OM2 to align with plans for supporting a range of Earth System Models.
+[ACCESS-NRI](https://www.access-nri.org.au) has assumed responsibility for supporting ACCESS-OM2-BGC for the Australian Research Community. As part of this support ACCESS-NRI has developed a new build and deployment system for ACCESS-OM2-BGC to align with plans for supporting a range of Earth System Models.
 
-Any questions about ACCESS-NRI releases of ACCESS-OM2 should be done through the [ACCESS-Hive Forum](https://forum.access-hive.org.au/). See the [ACCESS Help and Support topic](https://forum.access-hive.org.au/t/access-help-and-support/908) for details on how to do this.
+Any questions about ACCESS-NRI releases of ACCESS-OM2-BGC should be done through the [ACCESS-Hive Forum](https://forum.access-hive.org.au/). See the [ACCESS Help and Support topic](https://forum.access-hive.org.au/t/access-help-and-support/908) for details on how to do this.
 
 ### Build
 
-ACCESS-NRI is using [spack](https://spack.io), a build from source package manager designed for use with high performance computing. This repository contains a [spack environment](https://spack.readthedocs.io/en/latest/environments.html) definition file ([`spack.yaml`](https://github.com/ACCESS-NRI/ACCESS-OM2/blob/main/spack.yaml)) that defines all the essential components of the ACCESS-OM2 model, including exact versions.
+ACCESS-NRI is using [spack](https://spack.io), a build from source package manager designed for use with high performance computing. This repository contains a [spack environment](https://spack.readthedocs.io/en/latest/environments.html) definition file ([`spack.yaml`](https://github.com/ACCESS-NRI/ACCESS-OM2-BGC/blob/main/spack.yaml)) that defines all the essential components of the ACCESS-OM2-BGC model, including exact versions.
 
-Spack automatically builds all the components and their dependencies, producing model component executables. Spack already contains support for compiling thousands of common software packages. Spack packages for the components in ACCESS-OM2 are defined in the [spack packages repository](https://github.com/ACCESS-NRI/spack_packages/).
+Spack automatically builds all the components and their dependencies, producing model component executables. Spack already contains support for compiling thousands of common software packages. Spack packages for the components in ACCESS-OM2-BGC are defined in the [spack packages repository](https://github.com/ACCESS-NRI/spack_packages/).
 
-ACCESS-OM2 is built and deployed automatically to `gadi` on NCI (see below). However it is possible to use spack to compile the model using the `spack.yaml` environment file in this repository. To do so follow the [instructions on the ACCESS Forum for configuring spack on `gadi`](https://forum.access-hive.org.au/t/how-to-build-access-om2-on-gadi/1545). 
+ACCESS-OM2-BGC is built and deployed automatically to `gadi` on NCI (see below). However it is possible to use spack to compile the model using the `spack.yaml` environment file in this repository. To do so follow the [instructions on the ACCESS Forum for configuring spack on `gadi`](https://forum.access-hive.org.au/t/how-to-build-access-om2-on-gadi/1545). 
 
 Then clone this repository and run the following commands on `gadi`:
 ```
@@ -28,24 +28,24 @@ spack env create access-om2 spack.yaml
 spack env activate access-om2
 spack install
 ```
-to create a spack environment called `access-om2` and build all the ACCESS-OM2 components, the locations of which can be found using `spack find --paths`.
+to create a spack environment called `access-om2` and build all the ACCESS-OM2-BGC components, the locations of which can be found using `spack find --paths`.
 
 In contrast, the [COSIMA ACCESS-OM2 repository](https://github.com/COSIMA/access-om2) uses [submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to bring all the code dependencies into a single repository and build all the models together. 
 
 ### Deployment
   
-ACCESS-OM2 is deployed automatically when a new version of the [`spack.yaml`](https://github.com/ACCESS-NRI/ACCESS-OM2/blob/main/spack.yaml) file is committed to this repository and tagged with a new version. All the ACCESS-OM2 components are built using `spack` on `gadi` and installed under the [`vk83`](https://my.nci.org.au/mancini/project/vk83) project in `/g/data/vk83`. It is necessary to be a member of [`vk83`](https://my.nci.org.au/mancini/project/vk83) project to use ACCESS-NRI deployments of ACCESS-OM2. 
+ACCESS-OM2-BGC is deployed automatically when a new version of the [`spack.yaml`](https://github.com/ACCESS-NRI/ACCESS-OM2-BGC/blob/main/spack.yaml) file is committed to this repository and tagged with a new version. All the ACCESS-OM2-BGC components are built using `spack` on `gadi` and installed under the [`vk83`](https://my.nci.org.au/mancini/project/vk83) project in `/g/data/vk83`. It is necessary to be a member of [`vk83`](https://my.nci.org.au/mancini/project/vk83) project to use ACCESS-NRI deployments of ACCESS-OM2-BGC. 
 
-The deployment process also creates a GitHub release with the same tag. All releases are available under the [Releases page](https://github.com/ACCESS-NRI/ACCESS-OM2/releases). Each release has a changelog and meta-data with detailed information about the build and deployment, including:
+The deployment process also creates a GitHub release with the same tag. All releases are available under the [Releases page](https://github.com/ACCESS-NRI/ACCESS-OM2-BGC/releases). Each release has a changelog and meta-data with detailed information about the build and deployment, including:
 - paths on `gadi` to all executables built in the deployment process (`spack.location`)
 - a `spack.lock` file, which is a complete build provenance document, listing all the components that were built and their dependencies, versions, compiler version, build flags and build architecture
 - the environment `spack.yaml` file used for deployment
 
-Additionally the deployment creates environment modulefiles, the [standard method for deploying software on `gadi`](https://opus.nci.org.au/display/Help/Environment+Modules). To view available ACCESS-OM2 versions:
+Additionally the deployment creates environment modulefiles, the [standard method for deploying software on `gadi`](https://opus.nci.org.au/display/Help/Environment+Modules). To view available ACCESS-OM2-BGC versions:
 ```
 module use /g/data/vk83/apps/spack/0.20/release/modules/linux-rocky8-x86_64
-module avail access-om2
+module avail access-om2-bgc
 ```
 
-For users of ACCESS-OM2 model configurations released by ACCESS-NRI the exact location of the ACCESS-OM2 model executables is not required. Model configurations will be updated with new model components when necessary.
+For users of ACCESS-OM2-BGC model configurations released by ACCESS-NRI the exact location of the ACCESS-OM2-BGC model executables is not required. Model configurations will be updated with new model components when necessary.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   
 ACCESS-OM2-BGC is a global coupled ocean - sea ice model with WOMBAT biogeochemistrydeveloped by [COSIMA](http://www.cosima.org.au).
   
-ACCESS-OM2-BGC consists of the [MOM 5](https://github.com/ACCESS-NRI/MOM5) ocean model, [CICE 5](https://github.com/ACCESS-NRI/cice5) sea ice model, and a file-based atmosphere called [YATM](https://github.com/ACCESS-NRI/libaccessom2) coupled together using [OASIS3-MCT v2.0](https://github.com/ACCESS-NRI/oasis3-mct). ACCESS-OM2-BGC builds on the ACCESS-OM ([Bi et al., 2013](http://www.bom.gov.au/jshess/docs/2013/bi2_hres.pdf)) and AusCOM ([Roberts et al., 2007](https://50years.acs.org.au/content/dam/acs/50-years/journals/jrpit/JRPIT39.2.137.pdf); [Bi and Marsland, 2010](https://www.cawcr.gov.au/technical-reports/CTR_027.pdf)) models originally developed at [CSIRO](http://www.csiro.au).
+ACCESS-OM2-BGC consists of the [MOM 5](https://github.com/ACCESS-NRI/MOM5) ocean model with WOMBAT Biogeochemistry, [CICE 5](https://github.com/ACCESS-NRI/cice5) sea ice model, and a file-based atmosphere called [YATM](https://github.com/ACCESS-NRI/libaccessom2) coupled together using [OASIS3-MCT v2.0](https://github.com/ACCESS-NRI/oasis3-mct). ACCESS-OM2-BGC builds on the ACCESS-OM ([Bi et al., 2013](http://www.bom.gov.au/jshess/docs/2013/bi2_hres.pdf)) and AusCOM ([Roberts et al., 2007](https://50years.acs.org.au/content/dam/acs/50-years/journals/jrpit/JRPIT39.2.137.pdf); [Bi and Marsland, 2010](https://www.cawcr.gov.au/technical-reports/CTR_027.pdf)) models originally developed at [CSIRO](http://www.csiro.au).
   
 The model code, configurations and performance were described in [Kiss et al. (2020)](https://doi.org/10.5194/gmd-13-401-2020), with further details in the draft [ACCESS-OM2 technical report](https://github.com/COSIMA/ACCESS-OM2-1-025-010deg-report). The current code and configurations differ from this version in a number of ways (biogeochemistry, updated forcing, improvements and bug fixes), as described by [Solodoch et al. (2022)](https://doi.org/10.1029/2021GL097211), [Hayashida et al. (2023)](https://dx.doi.org/10.1029/2023JC019697), [Menviel et al. (2023)](https://doi.org/10.5194/egusphere-2023-390) and [Wang et al. (2023)](https://doi.org/10.5194/gmd-2023-123).
   
@@ -24,11 +24,11 @@ ACCESS-OM2-BGC is built and deployed automatically to `gadi` on NCI (see below).
 
 Then clone this repository and run the following commands on `gadi`:
 ```
-spack env create access-om2 spack.yaml
-spack env activate access-om2
+spack env create access-om2-bgc spack.yaml
+spack env activate access-om2-bgc
 spack install
 ```
-to create a spack environment called `access-om2` and build all the ACCESS-OM2-BGC components, the locations of which can be found using `spack find --paths`.
+to create a spack environment called `access-om2-bgc` and build all the ACCESS-OM2-BGC components, the locations of which can be found using `spack find --paths`.
 
 In contrast, the [COSIMA ACCESS-OM2 repository](https://github.com/COSIMA/access-om2) uses [submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to bring all the code dependencies into a single repository and build all the models together. 
 

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "./versions.schema.json",
-    "spack-packages": "2023.11.01",
-    "spack-config": "2023.11.01"
+    "spack-packages": "2024.03.20",
+    "spack-config": "2024.02.1"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "./versions.schema.json",
     "spack-packages": "2024.03.22",
-    "spack-config": "2024.02.1"
+    "spack-config": "2024.03.22"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "./versions.schema.json",
-    "spack-packages": "2024.03.20",
+    "spack-packages": "2024.03.22",
     "spack-config": "2024.02.1"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -41,7 +41,7 @@ spack:
       tcl:
         hash_length: 0
         include:
-        - access-om2
+        - access-om2-bgc
         - mom5
         - cice5
         - libaccessom2
@@ -56,7 +56,7 @@ spack:
               'SPACK_{name}_ROOT': '{prefix}'
         projections:
           all: '{name}/{version}'
-          access-om2: '{name}/2024.03.0'
+          access-om2-bgc: '{name}/2024.03.0'
           cice5: '{name}/2023.10.19'
           mom5: '{name}-bgc/2023.11.09'
           libaccessom2: '{name}/2023.10.26'

--- a/spack.yaml
+++ b/spack.yaml
@@ -8,12 +8,14 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - access-om2@git.2023.11.23
+  - access-om2@git.2024.03.0
   packages:
     cice5:
       require: '@git.2023.10.19'
     mom5:
-      require: '@git.2023.11.09 type=ACCESS-OM-BGC'
+      require: 
+        - @git.2023.11.09 
+        - type=ACCESS-OM-BGC'
     libaccessom2:
       require: '@git.2023.10.26'
     oasis3-mct:
@@ -56,7 +58,7 @@ spack:
               'SPACK_{name}_ROOT': '{prefix}'
         projections:
           all: '{name}/{version}'
-          access-om2: '{name}-bgc/2023.11.23'
+          access-om2: '{name}-bgc/2024.03.0'
           cice5: '{name}/2023.10.19'
           mom5: '{name}-bgc/2023.11.09'
           libaccessom2: '{name}/2023.10.26'

--- a/spack.yaml
+++ b/spack.yaml
@@ -8,14 +8,12 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - access-om2@git.2024.03.0
+  - access-om2-bgc@git.2024.03.0
   packages:
     cice5:
       require: '@git.2023.10.19'
     mom5:
-      require: 
-        - '@git.2023.11.09' 
-        - 'type=ACCESS-OM-BGC'
+      require: '@git.2023.11.09'
     libaccessom2:
       require: '@git.2023.10.26'
     oasis3-mct:
@@ -58,7 +56,7 @@ spack:
               'SPACK_{name}_ROOT': '{prefix}'
         projections:
           all: '{name}/{version}'
-          access-om2: '{name}-bgc/2024.03.0'
+          access-om2: '{name}/2024.03.0'
           cice5: '{name}/2023.10.19'
           mom5: '{name}-bgc/2023.11.09'
           libaccessom2: '{name}/2023.10.26'

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,8 +14,8 @@ spack:
       require: '@git.2023.10.19'
     mom5:
       require: 
-        - @git.2023.11.09 
-        - type=ACCESS-OM-BGC'
+        - '@git.2023.11.09' 
+        - 'type=ACCESS-OM-BGC'
     libaccessom2:
       require: '@git.2023.10.26'
     oasis3-mct:

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,3 +1,6 @@
+# Copyright 2024 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+#
 # This is a Spack Environment file.
 #
 # It describes a set of packages to be installed, along with
@@ -10,7 +13,7 @@ spack:
     cice5:
       require: '@git.2023.10.19'
     mom5:
-      require: '@git.2023.11.09'
+      require: '@git.2023.11.09 type=ACCESS-OM-BGC'
     libaccessom2:
       require: '@git.2023.10.26'
     oasis3-mct:
@@ -53,8 +56,8 @@ spack:
               'SPACK_{name}_ROOT': '{prefix}'
         projections:
           all: '{name}/{version}'
-          access-om2: '{name}/2023.11.23'
+          access-om2: '{name}-bgc/2023.11.23'
           cice5: '{name}/2023.10.19'
-          mom5: '{name}/2023.11.09'
+          mom5: '{name}-bgc/2023.11.09'
           libaccessom2: '{name}/2023.10.26'
           oasis3-mct: '{name}/2023.11.09'

--- a/spack.yaml
+++ b/spack.yaml
@@ -24,7 +24,7 @@ spack:
       require: '@4.5.2'
     parallelio:
       require: '@2.5.2'
-    nci-openmpi:
+    openmpi:
       require: '@4.0.2'
     all:
       compiler: [intel@19.0.5.281]


### PR DESCRIPTION
Add changes to convert from ACCESS-OM2 build type to ACCESS-OM2-BGC.

Requires changes to the README and the `spack.yaml` to use `type=ACCESS-OM2-BGC` which was added to the MOM5 spack package (see https://github.com/ACCESS-NRI/spack-packages/pull/72).