### PR TITLE
Update MOM5 to include ice-ocean BGC coupling bug fix

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -8,14 +8,14 @@
 spack:
   # add package specs to the `specs` list
   specs:
-    - access-om2-bgc@git.2024.03.1
+    - access-om2-bgc@git.2024.06.0
   packages:
     cice5:
       require:
         - '@git.2023.10.19'
     mom5:
       require:
-        - '@git.2023.11.09'
+        - '@git.2024.06.27'
     libaccessom2:
       require:
         - '@git.2023.10.26'
@@ -63,7 +63,7 @@ spack:
               'SPACK_{name}_ROOT': '{prefix}'
         projections:
           all: '{name}/{version}'
-          access-om2-bgc: '{name}/2024.03.1'
+          access-om2-bgc: '{name}/2024.06.0'
           cice5: '{name}/2023.10.19'
           mom5: '{name}-bgc/2023.11.09'
           libaccessom2: '{name}/2023.10.26'

--- a/spack.yaml
+++ b/spack.yaml
@@ -65,6 +65,6 @@ spack:
           all: '{name}/{version}'
           access-om2-bgc: '{name}/2024.06.0'
           cice5: '{name}/2023.10.19'
-          mom5: '{name}-bgc/2023.11.09'
+          mom5: '{name}-bgc/2024.06.27'
           libaccessom2: '{name}/2023.10.26'
           oasis3-mct: '{name}/2023.11.09'


### PR DESCRIPTION
Closes #7. Release version updated to `2024.06.0`