### PR TITLE
`hdf5` bug avoidance for `BGC 2024.06`

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/2-0-0.json",
     "spack": "0.21",
-    "spack-packages": "2024.04.20",
-    "spack-config": "2024.04.23"
+    "spack-packages": "2024.07.03",
+    "spack-config": "2024.07.02"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/2-0-0.json",
-    "spack": "0.21",
-    "spack-packages": "2024.07.03",
-    "spack-config": "2024.07.02"
+    "spack": "0.22",
+    "spack-packages": "2024.07.07",
+    "spack-config": "2024.07.05"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/2-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2024.07.07",
+    "spack-packages": "2024.07.08",
     "spack-config": "2024.07.05"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -36,7 +36,6 @@ spack:
     openmpi:
       require:
         - '@4.1.5'
-        - 'cppflags="-diag-disable=10441"'
     all:
       require:
         - '%intel@2021.10.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -32,7 +32,7 @@ spack:
         - '@4.6.1'
     parallelio:
       require:
-        - '@2.6.2'
+        - '@2.5.2'
     openmpi:
       require:
         - '@4.1.5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -8,9 +8,10 @@
 spack:
   # add package specs to the `specs` list
   specs:
-    - access-om2-bgc@git.2024.06.0
+    - access-om2-bgc@git.2024.06.1
   packages:
     cice5:
+      # Direct ACCESS-NRI Dependencies
       require:
         - '@git.2023.10.19'
     mom5:
@@ -22,6 +23,7 @@ spack:
     oasis3-mct:
       require:
         - '@git.2023.11.09'
+    # Other Dependencies
     netcdf-c:
       require:
         - '@4.9.2'
@@ -63,7 +65,7 @@ spack:
               'SPACK_{name}_ROOT': '{prefix}'
         projections:
           all: '{name}/{version}'
-          access-om2-bgc: '{name}/2024.06.0'
+          access-om2-bgc: '{name}/2024.06.1'
           cice5: '{name}/2023.10.19'
           mom5: '{name}-bgc/2024.06.27'
           libaccessom2: '{name}/2023.10.26'

--- a/spack.yaml
+++ b/spack.yaml
@@ -54,9 +54,9 @@ spack:
         hash_length: 0
         include:
         - access-om2-bgc
-        hide_implicits: true
+        exclude_implicits: true
         all:
-          autoload: direct
+          autoload: run
           conflict:
           - '{name}'
           environment:

--- a/spack.yaml
+++ b/spack.yaml
@@ -54,6 +54,10 @@ spack:
         hash_length: 0
         include:
         - access-om2-bgc
+        - mom5
+        - cice5
+        - libaccessom2
+        - oasis3-mct
         exclude_implicits: true
         all:
           autoload: run


### PR DESCRIPTION
In this PR:
* Update spack-config to `2024.07.02` to avoid the buggy `hdf5 1.14.3`. 
* Update `spack-packages` so it is in line with newer versions. 
* Add comments!

References original PR https://github.com/ACCESS-NRI/ACCESS-OM2-BGC/pull/12
References #13 