### PR TITLE
CI Infrastructure Update to `v3`                           

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@main
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v3
     with:
       model: ${{ vars.NAME }}
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - closed
     branches:
       - main
+      - dev
       - backport/*.*
     paths:
       - config/**
@@ -20,7 +21,20 @@ jobs:
   pr-ci:
     name: CI
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@main
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v3
+    with:
+      model: ${{ vars.NAME }}
+      pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
+    permissions:
+      pull-requests: write
+      contents: write
+      statuses: write
+    secrets: inherit
+
+  pr-comment:
+    name: Comment
+    if: github.event_name == 'issue_comment'
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v3
     with:
       model: ${{ vars.NAME }}
     permissions:
@@ -28,20 +42,10 @@ jobs:
       contents: write
     secrets: inherit
 
-  pr-comment:
-    name: Comment
-    if: github.event_name == 'issue_comment'
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@main
-    with:
-      model: ${{ vars.NAME }}
-    permissions:
-      pull-requests: write
-      contents: write
-
   pr-closed:
     name: Closed
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@main
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v3
     with:
       model: ${{ vars.NAME }}
     secrets: inherit


### PR DESCRIPTION
This PR updates the infrastructure to `v3`, which includes a fix to the `!bump [major|minor]` command.
It also allows Prereleases for branches into `dev`.
It also allows `!redeploy`, since that was not included in this repo. 

> [!NOTE]
> Existing CI will still work. Rebase your existing PRs if these features are of interest to you. 

References ACCESS-NRI/build-cd#109
References ACCESS-NRI/build-cd#193
