### PR TITLE
Deployment Infrastructure V4: Multi-HPC Deployments

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,9 +10,11 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v3
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v4
     with:
       model: ${{ vars.NAME }}
     permissions:
       contents: write
+      # Requires pull-requests:write because later workflows also handle on.pull_request trigger
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   pr-ci:
     name: CI
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v3
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v4
     with:
       model: ${{ vars.NAME }}
       pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
@@ -34,7 +34,7 @@ jobs:
   pr-comment:
     name: Comment
     if: github.event_name == 'issue_comment'
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v3
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v4
     with:
       model: ${{ vars.NAME }}
     permissions:
@@ -45,7 +45,7 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v3
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v4
     with:
-      model: ${{ vars.NAME }}
+      root-sbd: ${{ vars.NAME }}
     secrets: inherit


### PR DESCRIPTION
References issue ACCESS-NRI/build-cd#121 and detailed PR ACCESS-NRI/build-cd#218

> [!IMPORTANT]
> This PR is a major update to the deployment infrastructure. See below for the prerequisites for this repository to be able to merge this PR. 

## Background

This update to the deployment infrastructure allows deployment to multiple different HPC systems (or the same one but a different spack instance) in parallel. 

Some of the major changes relevant to a model deployment repository include:

* **`spack.yaml`**: A new way to format `spack.yaml` so that even if there are differences in HPC architecture or variants, we can still deploy using a single `spack.yaml`. See https://github.com/ACCESS-NRI/ACCESS-OM2/blob/ce5fdd27badabcbff464d50fcdc4df8e80a74123/spack.yaml for an example. You can still deploy using the traditional `spack.specs[0]` method. 

* **Choose Where To Deploy Pre/Releases**: Model Deployment Repositories can now set the repo-level `vars.PRERELEASE_DEPLOYMENT_TARGETS`/`vars.RELEASE_DEPLOYMENT_TARGETS` to choose which HPCs they deploy to. This is of the form of a space-separated list of GitHub Environments (minus any potential `Prerelease` bit), for example: `vars.PRERELEASE_DEPLOYMENT_TARGET` == `Gadi Setonix`, `vars.RELEASE_DEPLOYMENT_TARGET` == `Gadi`.

* **Updated Deployment Comments/Release Notes**: Since we can deploy to multiple targets, we've had to rework the style of the deployment comments/notes. Example of Release Notes here: https://github.com/ACCESS-NRI/build-cd/issues/200#issuecomment-2574326112 and Comment here: https://github.com/ACCESS-NRI/build-cd/issues/199#issuecomment-2555915869

## Prerequisites for Merging

 - [x] Add values for repo-level `vars.[PRE]RELEASE_DEPLOYMENT_TARGETS`
 - [x] Update repo-level `vars.SPACK_YAML_SCHEMA_VERSION` to `1-0-4`
 - [x] Update entrypoints to `@v4`, update `ci.yml pr-closed` jobs `model` input to `root-sbd`, update `cd.yml cd` job `permissions.pull-requests:write` (This PR!)
 - [x]  Add GitHub Environment for Releases with name `SUPERCOMPUTER Release` rather than `SUPERCOMPUTER` 

